### PR TITLE
ci(lint): extend commitlint length

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -19,3 +19,4 @@ policies:
       conventional:
         types: ["chore","build", "docs","ci","perf", "refactor", "style", "test", "release"]
         scopes: [".*"]
+        descriptionLength: 92


### PR DESCRIPTION
It has shown that the default length of 72 for commitlinting sometimes fails with renovate, and so we are in general raising that length for every repo on diggsweden.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
