### PR TITLE
refactor: drop clientId and stateJws from gateway HSM flow

### DIFF
--- a/app/src/main/java/se/digg/wallet/core/network/WalletOpaqueClient.kt
+++ b/app/src/main/java/se/digg/wallet/core/network/WalletOpaqueClient.kt
@@ -20,16 +20,12 @@ import se.digg.wallet.core.extensions.getOrThrow
 import se.digg.wallet.core.extensions.toECKey
 import se.wallet.client.gateway.client.HsmV0DeviceStatesClient
 import se.wallet.client.gateway.client.HsmV0RequestsClient
-import se.wallet.client.gateway.client.V0AccountsSecurityEnvelopesClient
 import se.wallet.client.gateway.models.EcJwkRequest
 import se.wallet.client.gateway.models.HsmAsyncStatus
 import se.wallet.client.gateway.models.HsmRequest
 import se.wallet.client.gateway.models.HsmRequestType
 import se.wallet.client.gateway.models.HsmResponse
 import se.wallet.client.gateway.models.RegisterStateRequest
-import se.wallet.client.gateway.models.SecurityEnvelopeRequest
-import se.wallet.client.gateway.models.SecurityEnvelopeType
-import timber.log.Timber
 
 class WalletOpaqueClient @Inject constructor(
     @param:GatewayHttpClient private val httpClient: HttpClient,
@@ -37,7 +33,6 @@ class WalletOpaqueClient @Inject constructor(
 
     private val deviceStatesClient = HsmV0DeviceStatesClient(httpClient)
     private val hsmRequestsClient = HsmV0RequestsClient(httpClient)
-    private val securityEnvelopesClient = V0AccountsSecurityEnvelopesClient(httpClient)
 
     override suspend fun registerState(
         publicKey: ECPublicKey,
@@ -63,13 +58,8 @@ class WalletOpaqueClient @Inject constructor(
             ),
         ).getOrThrow()
 
-        response.stateJws?.let {
-            persistStateEnvelope(it)
-        }
-
         return StateResponse(
             status = response.status,
-            clientId = response.clientId,
             devAuthorizationCode = response.devAuthorizationCode ?: "",
             serverJwsPublicKey = response.serverJwsPublicKey?.toECKey(),
             opaqueServerId = response.opaqueServerId ?: "",
@@ -86,8 +76,6 @@ class WalletOpaqueClient @Inject constructor(
 
     private fun hsmBody(request: HSMRequest) = HsmRequest(
         outerRequestJws = request.outerRequestJws,
-        clientId = request.clientId,
-        stateJws = request.stateJws,
     )
 
     private fun HSMOperationType.toRequestType() = when (this) {
@@ -107,12 +95,10 @@ class WalletOpaqueClient @Inject constructor(
             pollUntilComplete(checkNotNull(dto.id) { "Missing id in pending HSM response" })
         }
 
-    private suspend fun extractResult(dto: HsmResponse): String {
+    private fun extractResult(dto: HsmResponse): String {
         if (dto.status == HsmAsyncStatus.ERROR) {
             throw IOException("HSM operation failed")
         }
-
-        dto.stateJws?.let { persistStateEnvelope(it) }
 
         return checkNotNull(dto.result) { "HSM response missing result" }
     }
@@ -126,15 +112,5 @@ class WalletOpaqueClient @Inject constructor(
             }
         }
         throw IOException("HSM operation timed out after 30 attempts")
-    }
-
-    private suspend fun persistStateEnvelope(stateJws: String) {
-        try {
-            securityEnvelopesClient.addAccountSecurityEnvelope(
-                SecurityEnvelopeRequest(type = SecurityEnvelopeType.SIGN, content = stateJws),
-            ).getOrThrow()
-        } catch (e: Exception) {
-            Timber.w(e, "Failed to post security envelope")
-        }
     }
 }

--- a/app/src/main/java/se/digg/wallet/core/storage/user/UserModel.kt
+++ b/app/src/main/java/se/digg/wallet/core/storage/user/UserModel.kt
@@ -26,8 +26,8 @@ data class User(
 data class OpaqueSession(
     val serverPublicKeyJwk: String,
     val opaqueServerId: String,
-    val stateId: String,
     val opaqueContext: String,
+    val stateId: String?,
 )
 
 class DbConverters {

--- a/app/src/main/openapi/client-gateway.yaml
+++ b/app/src/main/openapi/client-gateway.yaml
@@ -104,46 +104,6 @@ paths:
         'default':
           $ref: '#/components/responses/default'
 
-  /v0/accounts/security-envelopes:
-    get:
-      tags:
-        - Account
-      summary: Get security envelopes
-      description: Returns the security envelopes associated with the authenticated account.
-      operationId: getAccountSecurityEnvelopes
-      responses:
-        '200':
-          description: Security envelopes retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SecurityEnvelopesResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        'default':
-          $ref: '#/components/responses/default'
-
-    post:
-      tags:
-        - Account
-      summary: Add a security envelope to an account
-      description: |
-        This operation will add a security envelope (typically used with the HSM) to the associated account.
-        An account can only have one security envelope for each type. Any existing envelope with the requested
-        type will be replaced.
-      operationId: addAccountSecurityEnvelope
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SecurityEnvelopeRequest'
-        required: true
-      responses:
-        '201':
-          description: The security envelope has been added to the account
-        'default':
-          $ref: '#/components/responses/default'
-
   /public/auth/session/challenge:
     get:
       tags:
@@ -540,43 +500,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/EcJwkRequest'
 
-    SecurityEnvelopeType:
-      type: string
-      description: 'Security envelope type enum constants.'
-      enum:
-        - SIGN
-        - OTHER
-
-    SecurityEnvelopeRequest:
-      properties:
-        type:
-          $ref: '#/components/schemas/SecurityEnvelopeType'
-        content:
-          type: string
-          description: The security envelope content. Typically encrypted opaque materials.
-          minLength: 1
-      required:
-        - type
-        - content
-
-    SecurityEnvelopeResponse:
-      type: object
-      properties:
-        content:
-          type: string
-          description: The security envelope content. Typically encrypted opaque materials.
-          minLength: 1
-      required:
-        - content
-
-    SecurityEnvelopesResponse:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/SecurityEnvelopeResponse'
-
     HsmRequestType:
       type: string
       description: The HSM Request type.
@@ -597,16 +520,8 @@ components:
           type: string
           minLength: 1
           description: Outer request JWS payload for the HSM operation.
-        clientId:
-          type: string
-          minLength: 1
-          description: Client identifier
-        stateJws:
-          type: string
-          description: Optional. Encoded device-state token. When present the BFF skips the Valkey lookup.
       required:
         - outerRequestJws
-        - clientId
 
     HsmAsyncStatus:
       type: string
@@ -634,9 +549,6 @@ components:
         resultUrl:
           type: string
           description: Gateway URL where the asynchronous operation result can be polled.
-        stateJws:
-          type: string
-          description: Updated device-state token. Present when status=complete. Persist and send as stateJws on the next request.
       required:
         - id
         - status
@@ -659,20 +571,14 @@ components:
       properties:
         status:
           type: string
-        clientId:
-          type: string
         devAuthorizationCode:
           type: string
         serverJwsPublicKey:
           $ref: '#/components/schemas/EcJwkResponse'
         opaqueServerId:
           type: string
-        stateJws:
-          type: string
-          description: JWS-encoded device state. Store alongside clientId and send as stateJws on subsequent requests.
       required:
         - status
-        - clientId
 
     AuthChallengeDto:
       type: object

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,7 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
-accessMechanism = { group = "se.digg.wallet", name = "access-mechanism", version = "0.0.3" }
+accessMechanism = { group = "se.digg.wallet", name = "access-mechanism", version = "0.0.1-SNAPSHOT" }
 
 [bundles]
 images = ["coil-compose", "coil-network"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,9 +23,12 @@ plugins {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        mavenLocal()
         google()
         mavenCentral()
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            mavenContent { snapshotsOnly() }
+        }
     }
 }
 


### PR DESCRIPTION
* chore: bump access-mechanism to 0.0.4
* feat: remove security-envelope endpoint and models from client-gateway spec
* refactor: stop sending clientId/stateJws in HSM requests and state registration
* refactor: make OpaqueSession.stateId nullable

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
